### PR TITLE
Show dashboard link when logged in

### DIFF
--- a/src/app/components/Navbar.tsx
+++ b/src/app/components/Navbar.tsx
@@ -1,48 +1,56 @@
 'use client';
+
 import Link from "next/link";
+import { useSession } from "@supabase/auth-helpers-react";
 import { Button } from "./ui/button";
 import ThemeToggle from "./ThemeToggle";
+
 export default function Navbar() {
+  const session = useSession();
+
   return (
     <nav className="text-black dark:text-white bg-white border-gray-200 dark:bg-gray-900 z-10 w-full">
-    <div className="max-w-screen-xl flex flex-wrap items-center justify-between mx-auto p-4">
-      {/* Logo */}
-      <Link href="/" className="flex items-center space-x-3 rtl:space-x-reverse">
-        <div className="h-8 w-8 rounded-full bg-music-gradient flex items-center justify-center">
-          <span className="text-white font-bold">M</span>
-        </div>
-        <span className="self-center text-2xl font-semibold whitespace-nowrap dark:text-white text-gradient">
-          MoodMix
-        </span>
-      </Link>
-
-      {/* Right section */}
-      <div className="flex md:order-2 space-x-2">
-        <Link href="/login">
-          <Button variant="outline" className="border-primary text-primary hover:bg-primary/10">
-            Sign In
-          </Button>
+      <div className="max-w-screen-xl flex flex-wrap items-center justify-between mx-auto p-4">
+        {/* Logo */}
+        <Link href="/" className="flex items-center space-x-3 rtl:space-x-reverse">
+          <div className="h-8 w-8 rounded-full bg-music-gradient flex items-center justify-center">
+            <span className="text-white font-bold">M</span>
+          </div>
+          <span className="self-center text-2xl font-semibold whitespace-nowrap dark:text-white text-gradient">
+            MoodMix
+          </span>
         </Link>
-        <ThemeToggle />
-        <button
-          data-collapse-toggle="navbar-cta"
-          type="button"
-          className="inline-flex items-center p-2 w-10 h-10 justify-center text-sm text-gray-500 rounded-lg md:hidden hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-gray-200 dark:text-gray-400 dark:hover:bg-gray-700 dark:focus:ring-gray-600"
-          aria-controls="navbar-cta"
-          aria-expanded="false"
-        >
-          <span className="sr-only">Open main menu</span>
-          <svg className="w-5 h-5" fill="none" viewBox="0 0 17 14">
-            <path
-              stroke="currentColor"
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              strokeWidth="2"
-              d="M1 1h15M1 7h15M1 13h15"
-            />
-          </svg>
-        </button>
-      </div>
+
+        {/* Right section */}
+        <div className="flex md:order-2 space-x-2">
+          <Link href={session ? "/dashboard" : "/login"}>
+            <Button
+              variant="outline"
+              className="border-primary text-primary hover:bg-primary/10"
+            >
+              {session ? "Dashboard" : "Sign In"}
+            </Button>
+          </Link>
+          <ThemeToggle />
+          <button
+            data-collapse-toggle="navbar-cta"
+            type="button"
+            className="inline-flex items-center p-2 w-10 h-10 justify-center text-sm text-gray-500 rounded-lg md:hidden hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-gray-200 dark:text-gray-400 dark:hover:bg-gray-700 dark:focus:ring-gray-600"
+            aria-controls="navbar-cta"
+            aria-expanded="false"
+          >
+            <span className="sr-only">Open main menu</span>
+            <svg className="w-5 h-5" fill="none" viewBox="0 0 17 14">
+              <path
+                stroke="currentColor"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth="2"
+                d="M1 1h15M1 7h15M1 13h15"
+              />
+            </svg>
+          </button>
+        </div>
 
       {/* Mobile menu */}
       <div className="items-center justify-between hidden w-full md:flex md:w-auto md:order-1" id="navbar-cta">

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useEffect } from 'react';
 import { useSession, useSupabaseClient } from '@supabase/auth-helpers-react';
 import { useRouter } from 'next/navigation';
 import { Button } from '../components/ui/button';
@@ -16,7 +16,7 @@ export default function Profile() {
     if (!session) {
       router.push('/login');
     }
-  }, [session]);
+  }, [session, router]);
 
   // Log out
   const handleLogout = async () => {
@@ -28,7 +28,7 @@ export default function Profile() {
   if (!session) return null;
 
   // Example user data
-  const [user, setUser] = useState({
+  const user = {
     name: 'Music Lover',
     email: session.user.email,
     likedSongs: [
@@ -47,7 +47,7 @@ export default function Profile() {
           'https://images.unsplash.com/photo-1470225620780-dba8ba36b745?auto=format&fit=crop&w=500&q=60',
       },
     ],
-  });
+  };
 
   return (
     <div className="container max-w-xl mx-auto py-4">

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -18,8 +18,10 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
     <html lang="en" suppressHydrationWarning>
       <body className={`${geistSans.variable} ${geistMono.variable} antialiased`}>
         <ThemeScript /> {/* ✅ Run before anything else */}
-        <Navbar />
-        <LayoutClient>{children}</LayoutClient>
+        <LayoutClient>
+          <Navbar />
+          {children}
+        </LayoutClient>
       </body>
     </html>
   );


### PR DESCRIPTION
## Summary
- Update Navbar to show a Dashboard link when a user session exists
- Move Navbar inside the layout's client provider to access auth context
- Clean up Dashboard page to satisfy lint rules

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689e3f8153688328982f5f1ebf9395d9